### PR TITLE
feat: add getCloudinaryFolders helper and automatic folder moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **getCloudinaryFolders Helper**: New helper function to fetch Cloudinary folders for custom implementations
+- **Automatic Folder Moves**: When folder changes, assets are moved in Cloudinary instead of duplicated
+- Complete example of custom folder selection field with dropdown and text input modes
+- Documentation for implementing custom folder selection UI
+- beforeChange hook to detect folder changes and use Cloudinary's rename API
+
+### Changed
+- Simplified approach to custom folder selection - users implement their own field components
+- Added example code showing the working pattern for folder selection
+
 ## [1.0.3] - 2025-01-03
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ collections: {
     folder: {
       path: 'uploads', // Default folder
       enableDynamic: true, // Let users type folder path per upload
+      enableFolderSelection: true, // Show dropdown with existing Cloudinary folders
       fieldName: 'cloudinaryFolder', // Custom field name
     },
   },
@@ -130,6 +131,31 @@ collections: {
   },
 }
 ```
+
+**Folder Options:**
+- `enableDynamic`: Allows users to type custom folder paths
+- `path`: Default folder path
+- `fieldName`: Custom name for the folder field (default: 'cloudinaryFolder')
+- `skipFieldCreation`: Don't create the field automatically
+
+**Automatic Folder Moves:**
+When `enableDynamic` is true, the plugin automatically detects folder changes and moves the asset in Cloudinary instead of creating a duplicate. This uses Cloudinary's rename API to preserve the same asset while updating its location.
+
+**Custom Folder Selection Field:**
+
+If you want to add a dropdown selector for existing Cloudinary folders, you can implement a custom field component. The plugin provides a `getCloudinaryFolders` helper function:
+
+```typescript
+import { getCloudinaryFolders } from 'payload-storage-cloudinary'
+
+// In your custom field component
+const folders = await getCloudinaryFolders()
+```
+
+See the [folder selection field example](./docs/examples/folder-selection-field.md) for a complete implementation that allows users to:
+- Select from existing Cloudinary folders
+- Create new folders
+- See folders in a hierarchical tree structure
 
 For custom field implementation:
 

--- a/dev/payload.config.ts
+++ b/dev/payload.config.ts
@@ -25,6 +25,18 @@ export default buildConfig({
                     name: 'alt',
                     type: 'text',
                 },
+                // Override the auto-generated cloudinaryFolder field with our custom selector
+                {
+                    name: 'cloudinaryFolder',
+                    type: 'text',
+                    label: 'Cloudinary Folder',
+                    admin: {
+                        components: {
+                            Field: '/src/components/field.tsx#selectField'
+                        },
+                        description: 'Select existing folder or create new one'
+                    }
+                }
             ],
         },
         {
@@ -96,6 +108,7 @@ export default buildConfig({
                         path: 'uploads',
                         enableDynamic: true,
                         fieldName: 'cloudinaryFolder',
+                        skipFieldCreation: true, // We're providing our own field
                     },
                     deleteFromCloudinary: false,
                     transformations: {

--- a/dev/src/components/field.client.tsx
+++ b/dev/src/components/field.client.tsx
@@ -1,0 +1,55 @@
+'use client'
+import {FieldLabel, SelectInput, TextInput, useField} from "@payloadcms/ui";
+import {OptionObject} from "payload";
+import {useState} from "react";
+
+export const FieldClient = ({folders}: {folders: OptionObject[]}) => {
+    const {path, setValue, value} = useField();
+    const [folderMode, setFolderMode] = useState<'existing' | 'new'>('existing');
+    
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <FieldLabel label={path}/>
+            
+            <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                    <input
+                        type="radio"
+                        name={`${path}_mode`}
+                        value="existing"
+                        checked={folderMode === 'existing'}
+                        onChange={() => setFolderMode('existing')}
+                    />
+                    Select existing folder
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                    <input
+                        type="radio"
+                        name={`${path}_mode`}
+                        value="new"
+                        checked={folderMode === 'new'}
+                        onChange={() => setFolderMode('new')}
+                    />
+                    Create new folder
+                </label>
+            </div>
+            
+            {folderMode === 'existing' ? (
+                <SelectInput
+                    path={path}
+                    name={path}
+                    value={value as string}
+                    options={folders}
+                    onChange={(e: any) => setValue(e.value)}
+                />
+            ) : (
+                <TextInput
+                    path={path}
+                    value={value as string}
+                    placeholder="Enter folder path (e.g., products/2024)"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+                />
+            )}
+        </div>
+    );
+}

--- a/dev/src/components/field.tsx
+++ b/dev/src/components/field.tsx
@@ -1,0 +1,7 @@
+import { getCloudinaryFolders } from 'payload-storage-cloudinary'
+import { FieldClient } from './field.client'
+
+export async function selectField() {
+    const folders = await getCloudinaryFolders()
+    return <FieldClient folders={folders} />
+}

--- a/docs/examples/folder-selection-field.md
+++ b/docs/examples/folder-selection-field.md
@@ -1,0 +1,184 @@
+# Custom Folder Selection Field Example
+
+This example shows how to implement a custom folder selection field that allows users to either select from existing Cloudinary folders or create new ones.
+
+## Implementation
+
+### 1. Create the Server Component (`field.tsx`)
+
+```typescript
+import { v2 as cloudinary } from 'cloudinary'
+import { FieldClient } from './field.client'
+
+cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME!,
+    api_key: process.env.CLOUDINARY_API_KEY!,
+    api_secret: process.env.CLOUDINARY_API_SECRET!,
+})
+
+async function getAllCloudinaryFolders() {
+    try {
+        const result = await cloudinary.api.root_folders()
+        return result.folders
+    } catch (error) {
+        console.error(error)
+        throw error
+    }
+}
+
+async function getSubfolders(folderPath: string) {
+    try {
+        const result = await cloudinary.api.sub_folders(folderPath)
+        return result.folders
+    } catch (error) {
+        console.error(error)
+        throw error
+    }
+}
+
+async function getAllFoldersRecursively(path: string = '', depth: number = 0): Promise<any[]> {
+    const allFolders = []
+    
+    try {
+        const folders = path === '' 
+            ? await getAllCloudinaryFolders()
+            : await getSubfolders(path)
+
+        for (const folder of folders) {
+            const indent = '  '.repeat(depth)
+            const icon = depth > 0 ? '└─ ' : ''
+
+            const displayName = depth > 0 ? folder.path : folder.name
+            
+            allFolders.push({
+                label: `${indent}${icon}${displayName}`,
+                value: folder.path,
+            })
+
+            const subfolders = await getAllFoldersRecursively(folder.path, depth + 1)
+            allFolders.push(...subfolders)
+        }
+    } catch (error) {
+        console.error(`Error fetching folders for path "${path}":`, error)
+    }
+    
+    return allFolders
+}
+
+export async function selectField() {
+    const rootFolder = {
+        label: '/ (root)',
+        value: ''
+    }
+    
+    const folders = [rootFolder, ...(await getAllFoldersRecursively())]
+    return <FieldClient folders={folders} />
+}
+```
+
+### 2. Create the Client Component (`field.client.tsx`)
+
+```typescript
+'use client'
+import { FieldLabel, SelectInput, TextInput, useField } from "@payloadcms/ui";
+import { OptionObject } from "payload";
+import { useState } from "react";
+
+export const FieldClient = ({ folders }: { folders: OptionObject[] }) => {
+    const { path, setValue, value } = useField();
+    const [folderMode, setFolderMode] = useState<'existing' | 'new'>('existing');
+    
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+            <FieldLabel label={path}/>
+            
+            <div style={{ display: 'flex', gap: '1rem', marginBottom: '0.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                    <input
+                        type="radio"
+                        name={`${path}_mode`}
+                        value="existing"
+                        checked={folderMode === 'existing'}
+                        onChange={() => setFolderMode('existing')}
+                    />
+                    Select existing folder
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}>
+                    <input
+                        type="radio"
+                        name={`${path}_mode`}
+                        value="new"
+                        checked={folderMode === 'new'}
+                        onChange={() => setFolderMode('new')}
+                    />
+                    Create new folder
+                </label>
+            </div>
+            
+            {folderMode === 'existing' ? (
+                <SelectInput
+                    path={path}
+                    name={path}
+                    value={value as string}
+                    options={folders}
+                    onChange={(e: any) => setValue(e.value)}
+                />
+            ) : (
+                <TextInput
+                    path={path}
+                    value={value as string}
+                    placeholder="Enter folder path (e.g., products/2024)"
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+                />
+            )}
+        </div>
+    );
+}
+```
+
+### 3. Use in Your Collection
+
+```typescript
+{
+    slug: 'media',
+    upload: {
+        disableLocalStorage: true,
+    },
+    fields: [
+        {
+            name: 'alt',
+            type: 'text',
+        },
+        {
+            name: 'cloudinaryFolder',
+            type: 'text',
+            admin: {
+                components: {
+                    Field: '/src/components/field.tsx#selectField'
+                }
+            }
+        }
+    ],
+}
+```
+
+## Using the Helper Function
+
+Alternatively, you can use the `getCloudinaryFolders` helper provided by the plugin:
+
+```typescript
+import { getCloudinaryFolders } from 'payload-storage-cloudinary'
+
+// In your custom field component
+export async function MyCustomField() {
+    const folders = await getCloudinaryFolders()
+    // Use folders in your component
+}
+```
+
+## Notes
+
+- The folder list is cached for 5 minutes to reduce API calls
+- Folders are displayed hierarchically with visual indicators
+- Users can switch between selecting existing folders and creating new ones
+- The field value is stored as the folder path string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "payload-storage-cloudinary",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cloudinary storage adapter for Payload CMS",
   "type": "module",
   "main": "./dist/index.js",
@@ -53,12 +53,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/your-github-username/payload-storage-cloudinary"
+    "url": "git+https://github.com/nlvcodes/payload-storage-cloudinary.git"
   },
   "bugs": {
-    "url": "https://github.com/your-github-username/payload-storage-cloudinary/issues"
+    "url": "https://github.com/nlvcodes/payload-storage-cloudinary/issues"
   },
-  "homepage": "https://github.com/your-github-username/payload-storage-cloudinary#readme",
+  "homepage": "https://github.com/nlvcodes/payload-storage-cloudinary#readme",
   "peerDependencies": {
     "@payloadcms/ui": "^3.0.0",
     "payload": "^3.0.0",

--- a/src/helpers/getCloudinaryFolders.ts
+++ b/src/helpers/getCloudinaryFolders.ts
@@ -1,0 +1,90 @@
+import { v2 as cloudinary } from 'cloudinary'
+import type { OptionObject } from 'payload'
+
+// Cache for folder data
+let cachedFolders: OptionObject[] | null = null
+let cacheTimestamp: number = 0
+const CACHE_DURATION = 5 * 60 * 1000 // 5 minutes in milliseconds
+
+async function getAllCloudinaryFolders() {
+  try {
+    const result = await cloudinary.api.root_folders()
+    return result.folders
+  } catch (error) {
+    console.error('Error fetching root folders:', error)
+    throw error
+  }
+}
+
+async function getSubfolders(folderPath: string) {
+  try {
+    const result = await cloudinary.api.sub_folders(folderPath)
+    return result.folders
+  } catch (error) {
+    console.error(`Error fetching subfolders for ${folderPath}:`, error)
+    throw error
+  }
+}
+
+async function getAllFoldersRecursively(path: string = '', depth: number = 0): Promise<any[]> {
+  const allFolders = []
+  
+  try {
+    const folders = path === '' 
+      ? await getAllCloudinaryFolders()
+      : await getSubfolders(path)
+
+    for (const folder of folders) {
+      const indent = '  '.repeat(depth)
+      const icon = depth > 0 ? '└─ ' : ''
+
+      const displayName = depth > 0 ? folder.path : folder.name
+      
+      allFolders.push({
+        label: `${indent}${icon}${displayName}`,
+        value: folder.path,
+      })
+
+      const subfolders = await getAllFoldersRecursively(folder.path, depth + 1)
+      allFolders.push(...subfolders)
+    }
+  } catch (error) {
+    console.error(`Error fetching folders for path "${path}":`, error)
+  }
+  
+  return allFolders
+}
+
+/**
+ * Get all Cloudinary folders as options for a select field
+ * @param useCache - Whether to use cached results (default: true)
+ * @returns Array of folder options with label and value
+ */
+export async function getCloudinaryFolders(useCache: boolean = true): Promise<OptionObject[]> {
+  const now = Date.now()
+  
+  // Check if cache is still valid
+  if (useCache && cachedFolders && (now - cacheTimestamp) < CACHE_DURATION) {
+    return cachedFolders
+  }
+  
+  // Fetch fresh data
+  const rootFolder = {
+    label: '/ (root)',
+    value: ''
+  }
+  
+  try {
+    const folders = [rootFolder, ...(await getAllFoldersRecursively())]
+    
+    // Update cache
+    cachedFolders = folders
+    cacheTimestamp = now
+    
+    return folders
+  } catch (error) {
+    console.error('Error fetching Cloudinary folders:', error)
+    // Return minimal set if there's an error
+    return [rootFolder]
+  }
+}

--- a/src/hooks/beforeChange.ts
+++ b/src/hooks/beforeChange.ts
@@ -1,0 +1,99 @@
+import { CollectionBeforeChangeHook } from 'payload'
+import { v2 as cloudinary } from 'cloudinary'
+import type { CloudinaryCollectionConfig } from '../types.js'
+import { getFolderConfig } from '../helpers/normalizeConfig.js'
+
+export const createBeforeChangeHook = (
+  collectionSlug: string,
+  config: CloudinaryCollectionConfig
+): CollectionBeforeChangeHook => async ({ data, originalDoc, req }) => {
+  // Only process if we have an existing document with a Cloudinary public ID
+  if (!originalDoc?.cloudinaryPublicId) {
+    return data
+  }
+
+  const folderConfig = getFolderConfig(config)
+  
+  // Check if dynamic folders are enabled
+  if (!folderConfig.enableDynamic) {
+    return data
+  }
+
+  const folderFieldName = folderConfig.fieldName || 'cloudinaryFolder'
+  
+  // Check if folder has changed
+  const oldFolder = originalDoc[folderFieldName] || ''
+  const newFolder = data[folderFieldName] || ''
+  
+  // If folder hasn't changed, nothing to do
+  if (oldFolder === newFolder) {
+    return data
+  }
+
+  // If we're changing folders and have a public ID, move the asset
+  try {
+    const oldPublicId = originalDoc.cloudinaryPublicId
+    
+    // Extract the filename from the old public ID
+    const parts = oldPublicId.split('/')
+    const filename = parts[parts.length - 1]
+    
+    // Construct new public ID with new folder
+    const newPublicId = newFolder ? `${newFolder}/${filename}` : filename
+    
+    // Use Cloudinary's rename API to move the asset
+    const result = await cloudinary.uploader.rename(
+      oldPublicId,
+      newPublicId,
+      {
+        resource_type: originalDoc.cloudinaryResourceType || 'auto',
+        overwrite: false,
+        invalidate: true,
+      }
+    )
+    
+    if (result.public_id) {
+      // Update the data with new Cloudinary info
+      data.cloudinaryPublicId = result.public_id
+      data.cloudinaryUrl = result.secure_url
+      data.cloudinaryVersion = result.version
+      data.url = result.secure_url
+      
+      // Update thumbnail URL with new path
+      const thumbnailUrl = cloudinary.url(result.public_id, {
+        secure: true,
+        version: result.version,
+        transformation: {
+          width: 150,
+          height: 150,
+          crop: 'fill',
+          gravity: 'auto',
+          quality: 'auto',
+          fetch_format: 'auto'
+        }
+      })
+      data.thumbnailURL = thumbnailUrl
+      
+      // Update the folder field to reflect the actual folder used
+      if (result.folder) {
+        data[folderFieldName] = result.folder
+      }
+      
+      req.payload.logger.info({
+        msg: `Moved Cloudinary asset from ${oldPublicId} to ${newPublicId}`,
+        collection: collectionSlug,
+      })
+    }
+  } catch (error) {
+    req.payload.logger.error({
+      msg: `Failed to move Cloudinary asset`,
+      collection: collectionSlug,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    })
+    
+    // Don't throw - let the update continue even if the move failed
+    // The asset will remain in the old location
+  }
+  
+  return data
+}


### PR DESCRIPTION
## Summary
- Export `getCloudinaryFolders` helper function for implementing custom folder selection fields
- Add automatic folder moves using Cloudinary's rename API when folder changes (prevents duplicates)
- Provide complete working example of custom folder selection with dropdown/text modes

## Key Features

### 1. getCloudinaryFolders Helper
- Fetches all Cloudinary folders recursively with hierarchical display
- 5-minute cache to reduce API calls
- Returns OptionObject[] ready for use in select fields

### 2. Automatic Folder Moves
- beforeChange hook detects when folder field changes
- Uses Cloudinary rename API to move asset instead of creating duplicate
- Updates all references (publicId, URLs, thumbnails)
- Graceful error handling - continues update even if move fails

### 3. Custom Field Example
- Complete working implementation in docs/examples
- Radio toggle between "Select existing" and "Create new" modes
- Hierarchical folder display with tree structure
- Updated dev environment demonstrates the pattern

## Test Plan
- [ ] Test folder selection in dev environment
- [ ] Verify assets move correctly when folder changes
- [ ] Confirm no duplicates are created
- [ ] Check that cache works for folder API calls
- [ ] Ensure backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)