### PR TITLE
fix: use public_id instead of use_filename for stream-based uploads

### DIFF
--- a/src/handlers/handleUpload.ts
+++ b/src/handlers/handleUpload.ts
@@ -402,7 +402,7 @@ function sanitizeFolderPath(folder: string): string {
 
 function buildUploadOptions(
   config: CloudinaryCollectionConfig,
-  _filename: string,
+  filename: string,
   data?: any,
   mimeType?: string,
 ): Record<string, any> {
@@ -460,8 +460,10 @@ function buildUploadOptions(
     // Cloudinary automatically creates folders if they don't exist
   }
 
-  if (config.useFilename !== undefined) {
-    options.use_filename = config.useFilename
+  if (config.useFilename && filename) {
+    const nameWithoutExt =
+      filename.lastIndexOf('.') > 0 ? filename.substring(0, filename.lastIndexOf('.')) : filename
+    options.public_id = nameWithoutExt
   }
 
   if (config.uniqueFilename !== undefined) {


### PR DESCRIPTION
## Problem

When `useFilename: true` is configured, files uploaded via `upload_stream` (buffer streams) always land on Cloudinary with the name `"file"`(such as when uploading a PDF file). This is because `buildUploadOptions` was setting `use_filename: true` on the Cloudinary upload options, which Cloudinary silently ignores for stream-based uploads.

## Root Cause

`buildUploadOptions` received the filename as its second parameter but named it `_filename` (intentionally unused), then set `use_filename: true` — an option that only works for file-path uploads, not streams.

## Fix

- Rename `_filename` → `filename` so the value is accessible
- When `config.useFilename` is true, explicitly set `options.public_id` to the filename without its extension

`public_id` works correctly for both stream and file-path uploads, and Cloudinary still prefixes it with the configured `folder` option as expected.

## Before / After

```ts
// Before
if (config.useFilename !== undefined) {
  options.use_filename = config.useFilename  // silently ignored for streams
}

// After
if (config.useFilename && filename) {
  const nameWithoutExt =
    filename.lastIndexOf('.') > 0 ? filename.substring(0, filename.lastIndexOf('.')) : filename
  options.public_id = nameWithoutExt  // works for both streams and file-path uploads
}
```